### PR TITLE
Enhance log services with p-limit for concurrent writes

### DIFF
--- a/game-backend/log-retry-worker-service/package-lock.json
+++ b/game-backend/log-retry-worker-service/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "dotenv": "^16.4.7",
         "kafkajs": "^2.2.4",
-        "mongoose": "^8.13.1"
+        "mongoose": "^8.13.1",
+        "p-limit": "^6.2.0"
       },
       "devDependencies": {
         "@types/node": "^22.14.0",
@@ -697,6 +698,21 @@
         "wrappy": "1"
       }
     },
+    "node_modules/p-limit": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+      "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1055,6 +1071,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/game-backend/log-retry-worker-service/package.json
+++ b/game-backend/log-retry-worker-service/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "dotenv": "^16.4.7",
     "kafkajs": "^2.2.4",
-    "mongoose": "^8.13.1"
+    "mongoose": "^8.13.1",
+    "p-limit": "^6.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/game-backend/log-retry-worker-service/src/config/env.ts
+++ b/game-backend/log-retry-worker-service/src/config/env.ts
@@ -13,4 +13,5 @@ export const env = {
   mongoUri: process.env.MONGO_URI,
   consumerGroup: process.env.KAFKA_CONSUMER_GROUP || 'log-retry-consumer',
   maxRetries: parseInt(process.env.MAX_RETRIES || '3', 10),
+  maxConcurrentWrites: parseInt(process.env.MAX_CONCURRENT_WRITES || '3', 10),
 };

--- a/game-backend/log-retry-worker-service/src/config/env.ts
+++ b/game-backend/log-retry-worker-service/src/config/env.ts
@@ -14,4 +14,5 @@ export const env = {
   consumerGroup: process.env.KAFKA_CONSUMER_GROUP || 'log-retry-consumer',
   maxRetries: parseInt(process.env.MAX_RETRIES || '3', 10),
   maxConcurrentWrites: parseInt(process.env.MAX_CONCURRENT_WRITES || '3', 10),
+  maxWriteRatePerSecond: parseInt(process.env.MAX_WRITE_RATE_PER_SECOND || '20', 10),
 };

--- a/game-backend/log-retry-worker-service/src/services/retry.service.ts
+++ b/game-backend/log-retry-worker-service/src/services/retry.service.ts
@@ -2,6 +2,7 @@ import { Kafka } from 'kafkajs';
 import { env } from '../config/env';
 import { LogModel } from '../models/log.model';
 import { mongoWriteLimit } from '../utils/limit';
+import { TokenBucketRateLimiter } from '../utils/rateLimiter';
 
 
 interface RetryLog {
@@ -12,6 +13,7 @@ interface RetryLog {
 
 export class RetryService {
   private producer;
+  private rateLimiter = new TokenBucketRateLimiter(env.maxWriteRatePerSecond, env.maxWriteRatePerSecond);
 
   constructor() {
     const kafka = new Kafka({
@@ -27,7 +29,7 @@ export class RetryService {
     const retryCount = log.retryCount || 0;
 
     try {
-      // Simulate retrying DB insert
+      await this.rateLimiter.wait();
       await mongoWriteLimit(() =>
         LogModel.create({
           playerId: log.playerId,

--- a/game-backend/log-retry-worker-service/src/services/retry.service.ts
+++ b/game-backend/log-retry-worker-service/src/services/retry.service.ts
@@ -1,6 +1,7 @@
 import { Kafka } from 'kafkajs';
 import { env } from '../config/env';
 import { LogModel } from '../models/log.model';
+import { mongoWriteLimit } from '../utils/limit';
 
 
 interface RetryLog {
@@ -27,10 +28,13 @@ export class RetryService {
 
     try {
       // Simulate retrying DB insert
-      await LogModel.create({
-        playerId: log.playerId,
-        logData: log.logData,
-      });
+      await mongoWriteLimit(() =>
+        LogModel.create({
+          playerId: log.playerId,
+          logData: log.logData,
+        })
+      );
+      
 
       console.log(`✅ Retry succeeded for player ${log.playerId}`);
     } catch (error) {

--- a/game-backend/log-retry-worker-service/src/utils/limit.ts
+++ b/game-backend/log-retry-worker-service/src/utils/limit.ts
@@ -1,4 +1,4 @@
 import pLimit from 'p-limit';
+import { env } from '../config/env';
 
-// Allow up to 3 concurrent writes
-export const mongoWriteLimit = pLimit(3);
+export const mongoWriteLimit = pLimit(env.maxConcurrentWrites);

--- a/game-backend/log-retry-worker-service/src/utils/limit.ts
+++ b/game-backend/log-retry-worker-service/src/utils/limit.ts
@@ -1,0 +1,4 @@
+import pLimit from 'p-limit';
+
+// Allow up to 3 concurrent writes
+export const mongoWriteLimit = pLimit(3);

--- a/game-backend/log-retry-worker-service/src/utils/rateLimiter.ts
+++ b/game-backend/log-retry-worker-service/src/utils/rateLimiter.ts
@@ -1,0 +1,25 @@
+export class TokenBucketRateLimiter {
+    private tokens: number;
+    private readonly capacity: number;
+    private readonly refillAmount: number;
+    private readonly refillInterval: number;
+  
+    constructor(capacity: number, refillRatePerSecond: number) {
+      this.capacity = capacity;
+      this.tokens = capacity;
+      this.refillAmount = refillRatePerSecond;
+      this.refillInterval = 1000;
+  
+      setInterval(() => {
+        this.tokens = Math.min(this.capacity, this.tokens + this.refillAmount);
+      }, this.refillInterval);
+    }
+  
+    public async wait(): Promise<void> {
+      while (this.tokens <= 0) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+      this.tokens--;
+    }
+  }
+  

--- a/game-backend/log-worker-service/package-lock.json
+++ b/game-backend/log-worker-service/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "dotenv": "^16.4.7",
         "kafkajs": "^2.2.4",
-        "mongoose": "^8.13.1"
+        "mongoose": "^8.13.1",
+        "p-limit": "^6.2.0"
       },
       "devDependencies": {
         "@types/node": "^22.14.0",
@@ -697,6 +698,21 @@
         "wrappy": "1"
       }
     },
+    "node_modules/p-limit": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+      "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1055,6 +1071,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/game-backend/log-worker-service/package.json
+++ b/game-backend/log-worker-service/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "dotenv": "^16.4.7",
     "kafkajs": "^2.2.4",
-    "mongoose": "^8.13.1"
+    "mongoose": "^8.13.1",
+    "p-limit": "^6.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/game-backend/log-worker-service/src/config/env.ts
+++ b/game-backend/log-worker-service/src/config/env.ts
@@ -17,4 +17,6 @@ export const env = {
   mongoUri: process.env.MONGO_URI,
   consumerGroup: process.env.KAFKA_CONSUMER_GROUP || 'log-consumer-group',
   kafkaRetryTopic: process.env.KAFKA_RETRY_TOPIC || 'log-retries',
+  maxConcurrentWrites: parseInt(process.env.MAX_CONCURRENT_WRITES || '3', 10),
+
 };

--- a/game-backend/log-worker-service/src/config/env.ts
+++ b/game-backend/log-worker-service/src/config/env.ts
@@ -18,5 +18,5 @@ export const env = {
   consumerGroup: process.env.KAFKA_CONSUMER_GROUP || 'log-consumer-group',
   kafkaRetryTopic: process.env.KAFKA_RETRY_TOPIC || 'log-retries',
   maxConcurrentWrites: parseInt(process.env.MAX_CONCURRENT_WRITES || '3', 10),
-
+  maxWriteRatePerSecond: parseInt(process.env.MAX_WRITE_RATE_PER_SECOND || '20', 10),
 };

--- a/game-backend/log-worker-service/src/services/log.service.ts
+++ b/game-backend/log-worker-service/src/services/log.service.ts
@@ -1,7 +1,7 @@
 import { LogModel } from '../models/log.model';
 import { TokenBucketRateLimiter } from '../utils/rateLimiter';
 import { Kafka } from 'kafkajs';
-import { env } from '../config/env'; // assuming you have access to env.KAFKA_RETRY_TOPIC
+import { env } from '../config/env'; 
 import { mongoWriteLimit } from '../utils/limit';
 
 interface LogInput {
@@ -19,7 +19,7 @@ export class LogService {
   }).producer();
   
 
-  private readonly rateLimiter = new TokenBucketRateLimiter(20, 20); 
+  private readonly rateLimiter = new TokenBucketRateLimiter(env.maxWriteRatePerSecond, env.maxWriteRatePerSecond); 
 
   constructor() {
     this.flushTimer = setInterval(() => this.flush(), this.flushInterval);

--- a/game-backend/log-worker-service/src/utils/limit.ts
+++ b/game-backend/log-worker-service/src/utils/limit.ts
@@ -1,4 +1,4 @@
 import pLimit from 'p-limit';
+import { env } from '../config/env';
 
-// Allow up to 3 concurrent writes
-export const mongoWriteLimit = pLimit(3);
+export const mongoWriteLimit = pLimit(env.maxConcurrentWrites);

--- a/game-backend/log-worker-service/src/utils/limit.ts
+++ b/game-backend/log-worker-service/src/utils/limit.ts
@@ -1,0 +1,4 @@
+import pLimit from 'p-limit';
+
+// Allow up to 3 concurrent writes
+export const mongoWriteLimit = pLimit(3);


### PR DESCRIPTION


## 🧵 PR: Add Concurrency Control to Log Processing Services

### 🧠 Purpose

Adds **concurrency control** to prevent MongoDB overload by limiting the number of simultaneous `insertMany()` or `create()` operations across all log-handling workers.

---

### ✅ What’s Included

#### 📦 `log-worker-service`
- Integrated [`[p-limit](https://www.npmjs.com/package/p-limit)`](https://www.npmjs.com/package/p-limit) utility
- Wraps `LogModel.insertMany(batch)` with a limiter
- Max 3 concurrent DB writes at any given moment
- Enhances stability under log bursts

#### 📦 `log-retry-worker-service`
- Same concurrency limiter added to `LogModel.create(...)` inside `RetryService`
- Prevents retry flood from overwhelming the database

---

### 📂 Shared Utility Structure

```bash
src/utils/limit.ts
├── export const mongoWriteLimit = pLimit(3);
```

Used in:
- `log-worker-service/src/services/log.service.ts`
- `log-retry-worker-service/src/services/retry.service.ts`

---

### 🧪 Benefits

- 🧼 Smooths DB load when many logs are processed in parallel
- 🛡️ Prevents spike-related crashes
- ⚙️ Keeps throughput stable across retries + batch writes
- 🔁 Easily tunable per environment (3 → 5, etc.)

---

### 🔧 Next Steps (Optional)

- Add concurrency control to `dlq-service` for full coverage
- Tune `p-limit` based on Mongo Atlas performance metrics
- Expose concurrent limit via `.env` if you want dynamic config
